### PR TITLE
compute max value per image for THOR maks and normalize by it

### DIFF
--- a/model_zoo/ddpm.py
+++ b/model_zoo/ddpm.py
@@ -141,7 +141,11 @@ class DDPM(nn.Module):
         # combined_mask = self.dilate_masks(combined_mask)
         combined_mask2 = torch.Tensor(combined_mask_np2).to(self.device)
 
-        combined_mask = (combined_mask / (torch.max(combined_mask) + 1e-8)).clip(0,1) 
+        # combined_mask = (combined_mask / (torch.max(combined_mask) + 1e-8)).clip(0,1) 
+        # compute max value per image and normalize by it
+        max_val = combined_mask.amax(dim=(1,2,3), keepdim=True)
+        combined_mask = (combined_mask / (max_val + 1e-8)).clamp(0,1)
+        
         # x_res_neg = (x-x_rec)
         return combined_mask, combined_mask2, torch.Tensor(x_res).to(self.device)
         # return torch.Tensor(x_res).to(self.device), torch.Tensor(x_res).to(self.device), torch.Tensor(x_res).to(self.device)


### PR DESCRIPTION
Compute per-image maximum for THOR mask normalization to support batch processing

Previously, THOR mask normalization was implicitly tied to single-image processing.
This commit computes the maximum value per image and normalizes each mask
individually, enabling correct behavior when applied to batched inputs.

This ensures consistent scaling across images within a batch.